### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -17,7 +17,7 @@ jobs:
         run: mvn spring-boot:build-image -Dspring-boot.build-image.imageName=edysegura/springboot-restful
       - uses: actions/checkout@master
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: edysegura/springboot-restful
           username: edysegura


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore